### PR TITLE
Fix typo in IntelliSense for listItemIndent

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
                   "default": false,
                   "description": "Stringify code blocks without language with fences."
                 },
-                "listItemIndent ": {
+                "listItemIndent": {
                   "type": "string",
                   "default": "tab",
                   "description": "How to indent the content from list items.",


### PR DESCRIPTION
There was an extra space at the end of the definition for `listItemIndent`, which means if you used IntelliSense to populate that setting, it would seem like it does not work.

Fixes #15