### PR TITLE
Support YAML configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1122,9 +1122,9 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -2152,9 +2152,9 @@
       }
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -2338,6 +2338,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -238,7 +238,8 @@
   },
   "dependencies": {
     "npm-module-path": "^2.0.2",
-    "remark": "^12.0.0"
+    "remark": "^12.0.0",
+    "yaml": "^1.10.0"
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,6 +119,7 @@ async function runRemark(document: vscode.TextDocument, range: vscode.Range): Pr
 					api = api.use(plugin.package);
 				}
 			} catch (err) {
+				console.error(err);
 				errors.push({
 					name: plugin.name,
 					err

--- a/src/test/suite/workspace.test.ts
+++ b/src/test/suite/workspace.test.ts
@@ -21,11 +21,7 @@ suite('Extension Test Suite', () => {
 		vscode.window.showInformationMessage('All tests done!');
 	});
 
-	test('parseWorkspaceConfig', async () => {
-		// The configPath looks overly convoluted since `__dirname` points to the directory of the resulting .js
-		// file inside the `out` directory and not this source .ts file.
-		const configPath = path.join(__dirname, '..', '..', '..', 'src', 'test', 'suite', 'json', '.remarkrc');
-		console.log('configPath', configPath);
+	const parseWorkspaceConfigTest = async (configPath : string) => {
 		const files =  [ vscode.Uri.parse(configPath) ];
 		const config = await workspace.parseWorkspaceConfig(files);
 
@@ -47,5 +43,19 @@ suite('Extension Test Suite', () => {
 
 		expect(check.object(config['first-heading']), 'config["first-heading"]').to.be.true;
 		expect(config['first-heading'].heading, 'config["first-heading"].heading').to.be.eq('Hello, .remarkrc file!');
+	};
+
+	test('parseWorkspaceConfig(json)', async () => {
+		// The configPath looks overly convoluted since `__dirname` points to the directory of the resulting .js
+		// file inside the `out` directory and not this source .ts file.
+		const configPath = path.join(__dirname, '..', '..', '..', 'src', 'test', 'suite', 'json', '.remarkrc');
+		await parseWorkspaceConfigTest(configPath);
+	});
+
+	test('parseWorkspaceConfig(yaml)', async () => {
+		// The configPath looks overly convoluted since `__dirname` points to the directory of the resulting .js
+		// file inside the `out` directory and not this source .ts file.
+		const configPath = path.join(__dirname, '..', '..', '..', 'src', 'test', 'suite', 'yaml', '.remarkrc.yml');
+		await parseWorkspaceConfigTest(configPath);
 	});
 });

--- a/src/test/suite/yaml/.remarkrc.yml
+++ b/src/test/suite/yaml/.remarkrc.yml
@@ -1,0 +1,9 @@
+plugins:
+- first-heading
+- github
+settings:
+  closeAtx: true
+github:
+  repository: https://github.com/mrmlnc/vscode-remark
+first-heading:
+  heading: Hello, .remarkrc file!

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -2,6 +2,7 @@
 
 import * as vscode from 'vscode';
 import { fileRead } from './fs';
+import * as yaml from 'yaml';
 
 export async function getWorkspaceConfig() {
 	const files = await vscode.workspace.findFiles('**/*remarkrc*', '**/node_modules/**');
@@ -12,7 +13,10 @@ export async function parseWorkspaceConfig(files : vscode.Uri[]) {
 	if (files.length === 0) {
 		return null;
 	}
-	if (files[0].fsPath.endsWith('.js')) {
+
+	const fileName = files[0].fsPath;
+
+	if (fileName.endsWith('.js')) {
 		try {
 			return require(files[0].fsPath);
 		}
@@ -21,8 +25,14 @@ export async function parseWorkspaceConfig(files : vscode.Uri[]) {
 			return 'SyntaxError';
 		}
 	}
+
 	const content = await fileRead(files[0].fsPath);
+	
 	try {
+		if (fileName.endsWith('.yml') || fileName.endsWith('.yaml')) {
+			return yaml.parse(content);
+		}
+		
 		return JSON.parse(content);
 	}
 	catch (err) {

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -17,6 +17,7 @@ export async function parseWorkspaceConfig(files : vscode.Uri[]) {
 			return require(files[0].fsPath);
 		}
 		catch (err) {
+			console.error(err);
 			return 'SyntaxError';
 		}
 	}
@@ -25,6 +26,7 @@ export async function parseWorkspaceConfig(files : vscode.Uri[]) {
 		return JSON.parse(content);
 	}
 	catch (err) {
+		console.error(err);
 		return 'SyntaxError';
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
 		"target": "es6",
 		"outDir": "out",
 		"lib": [
-			"es6"
+			"es6",
+			"dom"
 		],
 		"sourceMap": true,
 		"rootDir": "src",


### PR DESCRIPTION
This PR adds support for `.remarkrc.yml` files. It also adds logging to make it easier to understand why the plugin crashes. This PR builds on #20 which should be merged first. When it is, this PR will be rebased.

Fixes #18.